### PR TITLE
Запретил выделение иконки коррзины на нижней правой кнопке

### DIFF
--- a/src/components/CartButton.jsx
+++ b/src/components/CartButton.jsx
@@ -33,6 +33,8 @@ const CartButton = () => {
 
     const cartSize = Object.keys(cookies.cartProducts || {}).length
 
+    const disabledTextSelectionStyle={userSelect: "none", webUserSelect: "none" }
+
     return <div style={{ position: "absolute" }}><Button
         className={cx("blue", { pulse: cartSize })}
         fab={{ direction: "top", hoverEnabled: false }}
@@ -40,8 +42,8 @@ const CartButton = () => {
         large
         icon={cartSize ? <>
             <AddedProductsIndicator>{cartSize}</AddedProductsIndicator>
-            <CustomIcon >shopping_cart</CustomIcon>
-        </> : <CustomIcon className={"notranslate"}>shopping_cart</CustomIcon>}
+            <CustomIcon style={disabledTextSelectionStyle}>shopping_cart</CustomIcon>
+        </> : <CustomIcon style={disabledTextSelectionStyle} className={"notranslate"}>shopping_cart</CustomIcon>}
         node="button"
 
     >


### PR DESCRIPTION
Если нажать на кнопку корзины в нижнем правом углу на смартфоне один раз и дважды на ПК, то иконка корзины выделяется как текст с последующими ненужными функциями. Например перевод выделенного текста (на ПК) 
![image](https://user-images.githubusercontent.com/49411370/174442721-0298a6f3-bec3-4308-b846-efa313bca34a.png)
или запрос в поиск с всплывашкой, которя перекрывает почти всю кнопку (на смартфоне) 
![image](https://user-images.githubusercontent.com/49411370/174443197-b1ae4900-ffcb-4886-bd65-801d347d4e7e.png)
![image](https://user-images.githubusercontent.com/49411370/174442612-a5260b5b-1e1b-4df1-8e87-c6b16a4a92ea.png)


